### PR TITLE
Read subregion and boundary tags

### DIFF
--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -141,7 +141,7 @@ def from_meshio(m,
                     name_tag = (
                         m.cell_tags[tag][0]
                         if (hasattr(m, "cell_tags") and (tag in m.cell_tags))
-                        else str(tag)
+                        else int(tag)
                     )
                     cell_index_dict[name_tag] = (
                         {k: np.where(v == tag)[0]}

--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -138,10 +138,15 @@ def from_meshio(m,
             for k, v in cell_type_dict.items():
                 unique_tags = np.unique(v)
                 for tag in unique_tags:
-                    cell_index_dict[str(tag)] = (
+                    name_tag = (
+                        m.cell_tags[tag][0]
+                        if (hasattr(m, "cell_tags") and (tag in m.cell_tags))
+                        else str(tag)
+                    )
+                    cell_index_dict[name_tag] = (
                         {k: np.where(v == tag)[0]}
-                        if str(tag) not in cell_index_dict
-                        else cell_index_dict[str(tag)].update(
+                        if name_tag not in cell_index_dict
+                        else cell_index_dict[name_tag].update(
                             {k: np.where(v == tag)[0]}
                         )
                     )

--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -143,13 +143,10 @@ def from_meshio(m,
                         if (hasattr(m, "cell_tags") and (tag in m.cell_tags))
                         else int(tag)
                     )
-                    cell_index_dict[name_tag] = (
-                        {k: np.where(v == tag)[0]}
-                        if name_tag not in cell_index_dict
-                        else cell_index_dict[name_tag].update(
-                            {k: np.where(v == tag)[0]}
-                        )
-                    )
+                    if name_tag not in cell_index_dict:
+                        cell_index_dict[name_tag] = {k: np.where(v == tag)[0]}
+                    else:
+                        cell_index_dict[name_tag].update({k: np.where(v == tag)[0]})
 
     # create temporary mesh for matching boundary elements
     mtmp = mesh_type(p, t, validate=False)


### PR DESCRIPTION
Update the `io/meshio` module so that it can read the tags for both the sub-regions and boundaries for Gmesh `msh` files (version 4.1) and Salome `med` file.

Fixes https://github.com/MaMMoS-project/management/issues/245